### PR TITLE
Add a commands list to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 [![GitHub issues][github-issues-image]][github-issues-url]
 
+### Complete Command List
+
+[commands](docs/commands.md)
+
+### Overview
+
 MEDKIT is a tool to help you take control of your local environment configuration including:
 
 * Dotfile Management

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -3,9 +3,9 @@
 ### Basic Commands
 `medkit install dotfiles`: the basic, most often run command.  It will redot your symlinks, run your install.sh files, source your path files, etc.  If any bundles are configured in ~/.medkit, it will process them as well.
 
-`medkit {list,show,get} config`: Will list out your current configuration settings, and potentially describe any validity issues. //TODO pick a convention for list, show, or get
+`medkit show config`: Will list out your current configuration settings, and potentially describe any validity issues. //TODO pick a convention for list, show, or get
 
-`medkit {list,show,get} dotfiles`: will list all of the dotfiles that have been processed in your current environment.
+`medkit show dotfiles`: will list all of the dotfiles that have been processed in your current environment.
 
 ### Dotfiles Management Commands
 `medkit import dotfiles <file1,file2,file*,...>`: Will import the specified list of files into the users' dotfiles repo, either in the root, or optionally into the specified bundle

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,18 @@
+[Back to README](../README.md)
+
+### Basic Commands
+`medkit install dotfiles`: the basic, most often run command.  It will redot your symlinks, run your install.sh files, source your path files, etc.  If any bundles are configured in ~/.medkit, it will process them as well.
+
+`medkit {list,show,get} config`: Will list out your current configuration settings, and potentially describe any validity issues. //TODO pick a convention for list, show, or get
+
+`medkit {list,show,get} dotfiles`: will list all of the dotfiles that have been processed in your current environment.
+
+### Dotfiles Management Commands
+`medkit import dotfiles <file1,file2,file*,...>`: Will import the specified list of files into the users' dotfiles repo, either in the root, or optionally into the specified bundle
+
+`medkit import bundle <bundle-name> <file1,file2,file*,...>`: Will import the specified list of files into the users' dotfiles repo, either in the root, or optionally into the specified bundle
+
+`medkit init dotfiles`: will init a new dotfiles directory in the configured or default location (~/dotfiles) if one doesn't exist already.
+
+`medkit init bundle <bundle-name>`: will init a new bundles directory under the configured or default dotfiles/bundles directory.
+


### PR DESCRIPTION
Stubbed in a "commands list" document so that we can list out all of the ones we think of.  I am not necessarily claiming that the list is currently complete.  